### PR TITLE
Repopilot Fix: Issue #8 - ## System info

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -26,7 +26,7 @@ def main():
     optimizer = optim.SGD(model.parameters(), lr=lr, momentum=0.9)
     
     # Create directory for saving models
-    # os.makedirs('checkpoints', exist_ok=True)
+    os.makedirs('checkpoints', exist_ok=True)
     
     # Training loop
     best_accuracy = 0.0
@@ -44,4 +44,4 @@ def main():
     evaluate(model, device, data_module.test_dataloader(), "Test")
 
 if __name__ == '__main__':
-    main() 
+    main()


### PR DESCRIPTION
**Issue:** [AshStuff/JunkRepo#8](https://github.com/AshStuff/JunkRepo/issues/8)

**Explanation from Aider:**

To fix the issue, I will uncomment the line that creates the `checkpoints` directory using `os.makedirs`. This ensures that the directory exists before attempting to save the model state dictionary.

Here is the updated `train.py` file:

train.py
```
import torch
import torch.optim as optim
from data.dataset import MNISTDataModule
from model.mnist_model import MNISTNet
from augmentation.transforms import get_train_transforms, get_val_transforms
from utils import train_epoch, evaluate
import os

def main():
    # Training settings
    batch_size = 64
    epochs = 10
    lr = 0.01
    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
    
    # Initialize data module with augmentations
    data_module = MNISTDataModule(
        batch_size=batch_size,
        train_transforms=get_train_transforms(),
        val_transforms=get_val_transforms()
    )
    data_module.setup()
    
    # Initialize model
    model = MNISTNet().to(device)
    optimizer = optim.SGD(model.parameters(), lr=lr, momentum=0.9)
    
    # Create directory for saving models
    os.makedirs('checkpoints', exist_ok=True)
    
    # Training loop
    best_accuracy = 0.0
    for epoch in range(1, epochs + 1):
        train_epoch(model, device, data_module.train_dataloader(), optimizer, epoch)
        
        # Evaluate on validation set
        evaluate(model, device, data_module.val_dataloader(), "Validation")
        
        # Save best model
        if epoch % 5 == 0:
            torch.save(model.state_dict(), f'checkpoints/mnist_model_epoch_{epoch}.pt')
    
    # Final evaluation on test set
    evaluate(model, device, data_module.test_dataloader(), "Test")

if __name__ == '__main__':
    main()
```