### PR TITLE
Repopilot Fix: Issue #32 - ## System info

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -31,7 +31,7 @@ def evaluate(model, device, data_loader, set_name="Test"):
             correct += pred.eq(target.view_as(pred)).sum().item()
 
     loss /= len(data_loader.dataset)
-    accuracy = 0.0
+    accuracy = (correct / len(data_loader.dataset)) * 100.0
     
     print(f'\n{set_name} set: Average loss: {loss:.4f}, '
-          f'Accuracy: {accuracy:.2f}%\n') 
+          f'Accuracy: {accuracy:.2f}%\n')


### PR DESCRIPTION
**Issue:** [AshStuff/MnistClassification#32](https://github.com/AshStuff/MnistClassification/issues/32)

**Explanation from Aider:**

The bug lies in the `evaluate` function where the `accuracy` variable is not correctly computed. The current implementation calculates the number of correct predictions but does not convert this count into a percentage relative to the total number of samples. To fix this, we need to compute the accuracy as `(correct / len(data_loader.dataset)) * 100`.

### Changes

I will update the `evaluate` function in `utils.py` to correctly calculate and print the accuracy.

utils.py
```
import torch
import torch.nn.functional as F
from tqdm import tqdm

def train_epoch(model, device, train_loader, optimizer, epoch):
    model.train()
    pbar = tqdm(train_loader, desc=f'Epoch {epoch}')
    
    for batch_idx, (data, target) in enumerate(pbar):
        data, target = data.to(device), target.to(device)
        optimizer.zero_grad()
        output = model(data)
        loss = F.nll_loss(output, target)
        loss.backward()
        optimizer.step()
        
        if batch_idx % 100 == 0:
            pbar.set_postfix({'Loss': loss.item()})

def evaluate(model, device, data_loader, set_name="Test"):
    model.eval()
    loss = 0
    correct = 0
    
    with torch.no_grad():
        for data, target in data_loader:
            data, target = data.to(device), target.to(device)
            output = model(data)
            loss += F.nll_loss(output, target, reduction='sum').item()
            pred = output.argmax(dim=1, keepdim=True)
            correct += pred.eq(target.view_as(pred)).sum().item()

    loss /= len(data_loader.dataset)
    accuracy = (correct / len(data_loader.dataset)) * 100.0
    
    print(f'\n{set_name} set: Average loss: {loss:.4f}, '
          f'Accuracy: {accuracy:.2f}%\n')
```