### PR TITLE
Repopilot Fix: Issue #32 - ## System info

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -33,5 +33,8 @@ def evaluate(model, device, data_loader, set_name="Test"):
     loss /= len(data_loader.dataset)
     accuracy = 0.0
     
+    if correct > 0:
+        accuracy = (correct / len(data_loader.dataset)) * 100
+
     print(f'\n{set_name} set: Average loss: {loss:.4f}, '
-          f'Accuracy: {accuracy:.2f}%\n') 
+          f'Accuracy: {accuracy:.2f}%\n')


### PR DESCRIPTION
**Issue:** [AshStuff/MnistClassification#32](https://github.com/AshStuff/MnistClassification/issues/32)

**Explanation from Aider:**

The reported issue is that the accuracy is always 0%. This suggests that there might be a problem with how the model's predictions are being evaluated or compared to the ground truth labels. 

Upon reviewing the `evaluate` function in `utils.py`, I noticed that the variable `accuracy` is not being updated correctly. The line `accuracy = 0.0` initializes it to zero, but it never gets updated based on the actual performance of the model.

To fix this issue, we need to calculate the accuracy by dividing the number of correct predictions by the total number of predictions and then multiplying by 100 to get a percentage.

### Changes

I will update the `evaluate` function to correctly calculate and print the accuracy.

utils.py
```
import torch
import torch.nn.functional as F
from tqdm import tqdm

def train_epoch(model, device, train_loader, optimizer, epoch):
    model.train()
    pbar = tqdm(train_loader, desc=f'Epoch {epoch}')
    
    for batch_idx, (data, target) in enumerate(pbar):
        data, target = data.to(device), target.to(device)
        optimizer.zero_grad()
        output = model(data)
        loss = F.nll_loss(output, target)
        loss.backward()
        optimizer.step()
        
        if batch_idx % 100 == 0:
            pbar.set_postfix({'Loss': loss.item()})

def evaluate(model, device, data_loader, set_name="Test"):
    model.eval()
    loss = 0
    correct = 0
    
    with torch.no_grad():
        for data, target in data_loader:
            data, target = data.to(device), target.to(device)
            output = model(data)
            loss += F.nll_loss(output, target, reduction='sum').item()
            pred = output.argmax(dim=1, keepdim=True)
            correct += pred.eq(target.view_as(pred)).sum().item()

    loss /= len(data_loader.dataset)
    accuracy = 0.0
    
    if correct > 0:
        accuracy = (correct / len(data_loader.dataset)) * 100

    print(f'\n{set_name} set: Average loss: {loss:.4f}, '
          f'Accuracy: {accuracy:.2f}%\n')
```

### Explanation of Changes

1. **Calculate Accuracy**: I added a conditional check to ensure that `correct` is greater than 0 before calculating the accuracy. This prevents division by zero.
2. **Update Accuracy Calculation**: The accuracy is now calculated as `(correct / len(data_loader.dataset)) * 100`, which gives the percentage of correct predictions.

With these changes, the accuracy should be correctly reported during evaluation.