### PR TITLE
Repopilot Fix: Issue #32 - ## System info

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -31,7 +31,7 @@ def evaluate(model, device, data_loader, set_name="Test"):
             correct += pred.eq(target.view_as(pred)).sum().item()
 
     loss /= len(data_loader.dataset)
-    accuracy = 0.0
+    accuracy = 100. * correct / len(data_loader.dataset)  # Calculate accuracy
     
     print(f'\n{set_name} set: Average loss: {loss:.4f}, '
-          f'Accuracy: {accuracy:.2f}%\n') 
+          f'Accuracy: {accuracy:.2f}%\n')


### PR DESCRIPTION
**Issue:** [AshStuff/MnistClassification#32](https://github.com/AshStuff/MnistClassification/issues/32)

**Explanation from Aider:**

The reported issue is that the accuracy is always 0%. This suggests that there might be a problem with how the model's predictions are being evaluated or displayed. Specifically, the `evaluate` function does not correctly calculate and print the accuracy.

In the `evaluate` function, the variable `accuracy` is initialized to 0.0 but never updated based on the actual number of correct predictions. This means that the printed accuracy will always be 0%.

To fix this issue, we need to update the `evaluate` function to correctly calculate and print the accuracy.

### Changes

1. Update the `evaluate` function to calculate and print the accuracy correctly.
2. Ensure that the `accuracy` variable is updated based on the number of correct predictions.

Here is the updated `utils.py` file:

utils.py
```
import torch
import torch.nn.functional as F
from tqdm import tqdm

def train_epoch(model, device, train_loader, optimizer, epoch):
    model.train()
    pbar = tqdm(train_loader, desc=f'Epoch {epoch}')
    
    for batch_idx, (data, target) in enumerate(pbar):
        data, target = data.to(device), target.to(device)
        optimizer.zero_grad()
        output = model(data)
        loss = F.nll_loss(output, target)
        loss.backward()
        optimizer.step()
        
        if batch_idx % 100 == 0:
            pbar.set_postfix({'Loss': loss.item()})

def evaluate(model, device, data_loader, set_name="Test"):
    model.eval()
    loss = 0
    correct = 0
    
    with torch.no_grad():
        for data, target in data_loader:
            data, target = data.to(device), target.to(device)
            output = model(data)
            loss += F.nll_loss(output, target, reduction='sum').item()
            pred = output.argmax(dim=1, keepdim=True)
            correct += pred.eq(target.view_as(pred)).sum().item()

    loss /= len(data_loader.dataset)
    accuracy = 100. * correct / len(data_loader.dataset)  # Calculate accuracy
    
    print(f'\n{set_name} set: Average loss: {loss:.4f}, '
          f'Accuracy: {accuracy:.2f}%\n')
```

### Explanation of Changes

1. **Calculate Accuracy**: The line `accuracy = 100. * correct / len(data_loader.dataset)` calculates the accuracy as a percentage.
2. **Update Print Statement**: The print statement now includes the calculated accuracy.

With these changes, the accuracy should be correctly calculated and displayed during evaluation.