### PR TITLE
Repopilot Fix: Issue #32 - ## System info

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -31,7 +31,7 @@ def evaluate(model, device, data_loader, set_name="Test"):
             correct += pred.eq(target.view_as(pred)).sum().item()
 
     loss /= len(data_loader.dataset)
-    accuracy = 0.0
+    accuracy = 100. * correct / len(data_loader.dataset)
     
     print(f'\n{set_name} set: Average loss: {loss:.4f}, '
-          f'Accuracy: {accuracy:.2f}%\n') 
+          f'Accuracy: {accuracy:.2f}%\n')


### PR DESCRIPTION
**Issue:** [AshStuff/MnistClassification#32](https://github.com/AshStuff/MnistClassification/issues/32)

**Explanation from Aider:**

The reported issue is that the accuracy is always 0%. This suggests that there might be a problem with how the accuracy is being calculated or displayed. Let's review the relevant parts of the code:

1. **Accuracy Calculation**: The `evaluate` function calculates the loss and prints it, but it does not calculate or print the accuracy.
2. **Data Normalization**: The data normalization in both training and validation transforms uses the same mean and standard deviation `(0.1307,)`, which is appropriate for MNIST.

### Changes

To fix this issue, we need to ensure that the accuracy is calculated and printed correctly. We will modify the `evaluate` function to calculate and print the accuracy.

### Updated Files

#### utils.py
```
import torch
import torch.nn.functional as F
from tqdm import tqdm

def train_epoch(model, device, train_loader, optimizer, epoch):
    model.train()
    pbar = tqdm(train_loader, desc=f'Epoch {epoch}')
    
    for batch_idx, (data, target) in enumerate(pbar):
        data, target = data.to(device), target.to(device)
        optimizer.zero_grad()
        output = model(data)
        loss = F.nll_loss(output, target)
        loss.backward()
        optimizer.step()
        
        if batch_idx % 100 == 0:
            pbar.set_postfix({'Loss': loss.item()})

def evaluate(model, device, data_loader, set_name="Test"):
    model.eval()
    loss = 0
    correct = 0
    
    with torch.no_grad():
        for data, target in data_loader:
            data, target = data.to(device), target.to(device)
            output = model(data)
            loss += F.nll_loss(output, target, reduction='sum').item()
            pred = output.argmax(dim=1, keepdim=True)
            correct += pred.eq(target.view_as(pred)).sum().item()

    loss /= len(data_loader.dataset)
    accuracy = 100. * correct / len(data_loader.dataset)
    
    print(f'\n{set_name} set: Average loss: {loss:.4f}, '
          f'Accuracy: {accuracy:.2f}%\n')
```

### Explanation of Changes

1. **Accuracy Calculation**: In the `evaluate` function, we added a calculation for accuracy:
   ```python
   accuracy = 100. * correct / len(data_loader.dataset)
   ```
   This line calculates the percentage of correctly predicted samples.

2. **Printing Accuracy**: We updated the print statement to include the accuracy:
   ```python
   print(f'\n{set_name} set: Average loss: {loss:.4f}, '
         f'Accuracy: {accuracy:.2f}%\n')
   ```
   This ensures that the accuracy is printed along with the loss.

With these changes, the `evaluate` function will now correctly calculate and print the accuracy, which should resolve the issue of always showing 0% accuracy.